### PR TITLE
link color fix for online

### DIFF
--- a/src/templates/BlogPost.vue
+++ b/src/templates/BlogPost.vue
@@ -31,7 +31,7 @@ p.post-date {
   margin-bottom: 1em;
 }
 
-.prose.post-content p a {
+.prose.post-content a {
   color: #111827;
 }
 </style>

--- a/src/templates/BlogPost.vue
+++ b/src/templates/BlogPost.vue
@@ -30,4 +30,8 @@ h1.post-title {
 p.post-date {
   margin-bottom: 1em;
 }
+
+.prose.post-content p a {
+  color: #111827;
+}
 </style>


### PR DESCRIPTION
Strange, it works locally but not globally
<img width="1058" alt="Screenshot 2022-10-20 at 15 33 21" src="https://user-images.githubusercontent.com/1001610/196968713-c5a18d1c-0034-490e-90bf-3d5f53210a43.png">
<img width="990" alt="Screenshot 2022-10-20 at 15 30 48" src="https://user-images.githubusercontent.com/1001610/196968729-352a8639-1fce-4979-9c07-d3640c292ca5.png">


- [X] Possible fix